### PR TITLE
Add PreferenceUtil

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Any kinds of contributions including **pull requests**, **writing issues**, **em
     1. [IntArrayUtil](https://github.com/TheFinestArtist/AndroidBaseUtils#intarrayutil-)
     1. [SparseArrayUtil](https://github.com/TheFinestArtist/AndroidBaseUtils#sparsearrayutil-)
     1. [ThreadUtil](https://github.com/TheFinestArtist/AndroidBaseUtils#threadutil-)
+    1. [PreferenceUtil](https://github.com/TheFinestArtist/AndroidBaseUtils#preferenceutil-)
 1. Upcoming utils
     1. AgeUtil
     1. AudioManagerUtil
@@ -437,10 +438,32 @@ ThreadUtil helps to deal with thread conveniently.
 boolean     isMain();
 ```
 
+## PreferenceUtil (☆☆☆☆☆)
+PreferenceUtil helps to manage application-wide preferences conveniently.
+
+```java
+boolean        get(String key, boolean defValue);
+int            get(String key, int defValue);
+float          get(String key, float defValue);
+long           get(String key, long defValue);
+String         get(String key, String defValue);
+Set<String>    get(String key, Set<String> defValue);
+C              get(String key, C defValue);
+void           put(String key, boolean value);
+void           put(String key, int value);
+void           put(String key, float value);
+void           put(String key, long value);
+void           put(String key, String value);
+void           put(String key, Set<String> value);
+void           put(String key, C value);
+void           remove(String key);
+```
+
 # Contributors
 [Leonardo Taehwan Kim](https://github.com/thefinestartist)  
 [Marcos Trujillo](https://github.com/Aracem)  
-[Min Kim](https://github.com/openyourboxes)
+[Min Kim](https://github.com/openyourboxes)  
+[Robin Gustafsson](https://github.com/rgson)
 
 # License
 

--- a/utils/src/androidTest/java/com/thefinestartist/utils/etc/PreferenceUtilTest.java
+++ b/utils/src/androidTest/java/com/thefinestartist/utils/etc/PreferenceUtilTest.java
@@ -1,0 +1,121 @@
+package com.thefinestartist.utils.etc;
+
+import android.test.AndroidTestCase;
+import android.test.suitebuilder.annotation.MediumTest;
+import android.test.suitebuilder.annotation.SmallTest;
+
+import com.thefinestartist.Base;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Tests the PreferenceUtil class.
+ *
+ * @author Robin Gustafsson
+ */
+public class PreferenceUtilTest extends AndroidTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        Base.initialize(getContext());
+    }
+
+    @SmallTest
+    public void testStoreBoolean() {
+        final String key = "TEST_BOOLEAN";
+        final boolean expected = true;
+        final boolean defValue = false;
+
+        PreferenceUtil.put(key, expected);
+        boolean actual = PreferenceUtil.get(key, defValue);
+        assertEquals(expected, actual);
+    }
+
+    @SmallTest
+    public void testStoreInt() {
+        final String key = "TEST_INT";
+        final int expected = 321;
+        final int defValue = 0;
+
+        PreferenceUtil.put(key, expected);
+        int actual = PreferenceUtil.get(key, defValue);
+        assertEquals(expected, actual);
+    }
+
+    @SmallTest
+    public void testStoreFloat() {
+        final String key = "TEST_FLOAT";
+        final float expected = 12.3f;
+        final float defValue = 0.0f;
+
+        PreferenceUtil.put(key, expected);
+        float actual = PreferenceUtil.get(key, defValue);
+        assertEquals(expected, actual);
+    }
+
+    @SmallTest
+    public void testStoreLong() {
+        final String key = "TEST_LONG";
+        final long expected = 321L;
+        final long defValue = 0L;
+
+        PreferenceUtil.put(key, expected);
+        long actual = PreferenceUtil.get(key, defValue);
+        assertEquals(expected, actual);
+    }
+
+    @SmallTest
+    public void testStoreString() {
+        final String key = "TEST_STRING";
+        final String expected = "Lorem ipsum";
+        final String defValue = null;
+
+        PreferenceUtil.put(key, expected);
+        String actual = PreferenceUtil.get(key, defValue);
+        assertEquals(expected, actual);
+    }
+
+    @SmallTest
+    public void testStoreStringSet() {
+        final String key = "TEST_STRINGSET";
+        final Set<String> expected = new HashSet<>();
+        expected.add("Lorem ipsum");
+        expected.add("dolor sit amet");
+        expected.add("consectetur adipiscing elit");
+        final Set<String> defValue = null;
+
+        PreferenceUtil.put(key, expected);
+        Set<String> actual = PreferenceUtil.get(key, defValue);
+        assertEquals(expected, actual);
+    }
+
+    @MediumTest
+    public void testStoreSerializable() {
+        final String key = "TEST_SERIALIZABLE";
+        final ArrayList<String> expected = new ArrayList<>();
+        expected.add("Lorem ipsum");
+        expected.add("dolor sit amet");
+        expected.add("consectetur adipiscing elit");
+        final ArrayList<String> defValue = new ArrayList<>();
+        defValue.add("Proin mollis dictum");
+
+        PreferenceUtil.put(key, expected);
+        ArrayList<String> actual = PreferenceUtil.get(key, defValue);
+        assertEquals(expected, actual);
+    }
+
+    @SmallTest
+    public void testRemove() {
+        final String key = "TEST_REMOVE";
+        final String expected = null;
+
+        PreferenceUtil.put(key, "Lorem ipsum");
+        PreferenceUtil.remove(key);
+        String actual = PreferenceUtil.get(key, expected);
+        assertEquals(expected, actual);
+    }
+
+}

--- a/utils/src/main/java/com/thefinestartist/utils/etc/PreferenceUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/etc/PreferenceUtil.java
@@ -1,0 +1,168 @@
+package com.thefinestartist.utils.etc;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.os.Build;
+import android.util.Base64;
+import android.util.Log;
+
+import com.thefinestartist.Base;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.util.Set;
+
+/**
+ * PreferenceUtil helps to manage application-wide preferences conveniently.
+ *
+ * @author Robin Gustafsson
+ */
+public class PreferenceUtil {
+
+    private static final String TAG = PreferenceUtil.class.getCanonicalName();
+
+    protected static final String PREFERENCES_NAME = PreferenceUtil.class.getCanonicalName();
+
+    private PreferenceUtil() { }
+
+
+    private static SharedPreferences getPreferences() {
+        return Base.getContext().getSharedPreferences(
+                PREFERENCES_NAME, Context.MODE_PRIVATE);
+    }
+
+
+    public static boolean get(String key, boolean defValue) {
+        return getPreferences().getBoolean(key, defValue);
+    }
+
+    public static int get(String key, int defValue) {
+        return getPreferences().getInt(key, defValue);
+    }
+
+    public static float get(String key, float defValue) {
+        return getPreferences().getFloat(key, defValue);
+    }
+
+    public static long get(String key, long defValue) {
+        return getPreferences().getLong(key, defValue);
+    }
+
+    public static String get(String key, String defValue) {
+        return getPreferences().getString(key, defValue);
+    }
+
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    public static Set<String> get(String key, Set<String> defValue) {
+        return getPreferences().getStringSet(key, defValue);
+    }
+
+    @TargetApi(Build.VERSION_CODES.FROYO)
+    public static <C extends Serializable> C get(String key, C defValue) {
+        ByteArrayInputStream bais = null;
+        ObjectInputStream ois = null;
+        C result = defValue;
+
+        String value = getPreferences().getString(key, null);
+        if (value != null) {
+            try {
+                byte[] decoded = Base64.decode(value.getBytes(), Base64.DEFAULT);
+                bais = new ByteArrayInputStream(decoded);
+                ois = new ObjectInputStream(bais);
+                result = (C) ois.readObject();
+
+            } catch (Exception e) {
+                Log.e(TAG, e.toString());
+
+            } finally {
+                if (ois != null) {
+                    try {
+                        ois.close();
+                    } catch (IOException e) {
+                        Log.e(TAG, e.toString());
+                    }
+                }
+                if (bais != null) {
+                    try {
+                        bais.close();
+                    } catch (IOException e) {
+                        Log.e(TAG, e.toString());
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
+
+
+    public static void put(String key, boolean value) {
+        getPreferences().edit().putBoolean(key, value).commit();
+    }
+
+    public static void put(String key, int value) {
+        getPreferences().edit().putInt(key, value).commit();
+    }
+
+    public static void put(String key, float value) {
+        getPreferences().edit().putFloat(key, value).commit();
+    }
+
+    public static void put(String key, long value) {
+        getPreferences().edit().putLong(key, value).commit();
+    }
+
+    public static void put(String key, String value) {
+        getPreferences().edit().putString(key, value).commit();
+    }
+
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    public static void put(String key, Set<String> value) {
+        getPreferences().edit().putStringSet(key, value).commit();
+    }
+
+    @TargetApi(Build.VERSION_CODES.FROYO)
+    public static <C extends Serializable> void put(String key, C value) {
+        ByteArrayOutputStream baos = null;
+        ObjectOutputStream oos = null;
+
+        try {
+            baos = new ByteArrayOutputStream();
+            oos = new ObjectOutputStream(baos);
+            oos.writeObject(value);
+            byte[] encoded = Base64.encode(baos.toByteArray(), Base64.DEFAULT);
+            getPreferences().edit().putString(key, new String(encoded)).commit();
+
+        } catch (IOException e) {
+            Log.e(TAG, e.toString());
+            throw new RuntimeException(e);
+
+        } finally {
+            if (oos != null) {
+                try {
+                    oos.close();
+                } catch (IOException e) {
+                    Log.e(TAG, e.toString());
+                }
+            }
+            if (baos != null) {
+                try {
+                    baos.close();
+                } catch (IOException e) {
+                    Log.e(TAG, e.toString());
+                }
+            }
+        }
+    }
+
+
+    public static void remove(String key) {
+        getPreferences().edit().remove(key).commit();
+    }
+
+}


### PR DESCRIPTION
Hi,

I've created a utility class for managing application-wide preferences in a more convenient way. It's a more meticulously crafted re-implementation of a utility class I've personally found useful in previous projects.

The ``PreferenceUtil`` class offers uniform usage for all of the datatypes supported by ``SharedPreferences`` and adds additional functionality by utilizing serialization to allow for storing of other datatypes as well.

I've included instrumented unit tests and updated the documentation to go along with the new class.

If you think this is a useful addition, I'd be glad to see it included in the main repository.

~ rgson

P.S. I'm not sure how the stars in the README are determined, so those are perhaps incorrect.