### PR TITLE
Updated PreferenceUtil.

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ Proguard
 PreferenceUtil helps to manage application-wide preferences conveniently.
 
 ```java
+String         getDefaultName();
+void           setDefaultName(String name);
+
 boolean        get(String key, boolean defValue);
 int            get(String key, int defValue);
 float          get(String key, float defValue);
@@ -222,6 +225,15 @@ long           get(String key, long defValue);
 String         get(String key, String defValue);
 Set<String>    get(String key, Set<String> defValue);
 C              get(String key, C defValue);
+
+boolean        get(String name, String key, boolean defValue);
+int            get(String name, String key, int defValue);
+float          get(String name, String key, float defValue);
+long           get(String name, String key, long defValue);
+String         get(String name, String key, String defValue);
+Set<String>    get(String name, String key, Set<String> defValue);
+C              get(String name, String key, C defValue);
+
 void           put(String key, boolean value);
 void           put(String key, int value);
 void           put(String key, float value);
@@ -229,7 +241,20 @@ void           put(String key, long value);
 void           put(String key, String value);
 void           put(String key, Set<String> value);
 void           put(String key, C value);
+
+void           put(String name, String key, boolean value);
+void           put(String name, String key, int value);
+void           put(String name, String key, float value);
+void           put(String name, String key, long value);
+void           put(String name, String key, String value);
+void           put(String name, String key, Set<String> value);
+void           put(String name, String key, C value);
+
 void           remove(String key);
+void           remove(String name, String key);
+
+void           clear();
+void           clear(String name);
 ```
 
 ## UnitConverter (★★★★★)

--- a/utils/src/androidTest/java/com/thefinestartist/utils/etc/PreferenceUtilTest.java
+++ b/utils/src/androidTest/java/com/thefinestartist/utils/etc/PreferenceUtilTest.java
@@ -24,6 +24,28 @@ public class PreferenceUtilTest extends AndroidTestCase {
     }
 
     @SmallTest
+    public void testSetGetDefaultName() {
+        final String expected = "TEST_DEFAULT_NAME";
+
+        PreferenceUtil.setDefaultName(expected);
+        String actual = PreferenceUtil.getDefaultName();
+        assertEquals(expected, actual);
+    }
+
+    @SmallTest
+    public void testDifferentNames() {
+        final String name1 = "TEST_DIFFERENTNAMES_NAME1";
+        final String name2 = "TEST_DIFFERENTNAMES_NAME2";
+        final String key = "TEST_DIFFERENTNAMES_KEY";
+        final boolean value = true;
+        final boolean expected = false;
+
+        PreferenceUtil.put(name1, key, value);
+        boolean actual = PreferenceUtil.get(name2, key, expected);
+        assertEquals(expected, actual);
+    }
+
+    @SmallTest
     public void testStoreBoolean() {
         final String key = "TEST_BOOLEAN";
         final boolean expected = true;
@@ -31,6 +53,18 @@ public class PreferenceUtilTest extends AndroidTestCase {
 
         PreferenceUtil.put(key, expected);
         boolean actual = PreferenceUtil.get(key, defValue);
+        assertEquals(expected, actual);
+    }
+
+    @SmallTest
+    public void testStoreBooleanNamed() {
+        final String name = "TEST_NAMED";
+        final String key = "TEST_BOOLEAN";
+        final boolean expected = true;
+        final boolean defValue = false;
+
+        PreferenceUtil.put(name, key, expected);
+        boolean actual = PreferenceUtil.get(name, key, defValue);
         assertEquals(expected, actual);
     }
 
@@ -46,6 +80,18 @@ public class PreferenceUtilTest extends AndroidTestCase {
     }
 
     @SmallTest
+    public void testStoreIntNamed() {
+        final String name = "TEST_NAMED";
+        final String key = "TEST_INT";
+        final int expected = 321;
+        final int defValue = 0;
+
+        PreferenceUtil.put(name, key, expected);
+        int actual = PreferenceUtil.get(name, key, defValue);
+        assertEquals(expected, actual);
+    }
+
+    @SmallTest
     public void testStoreFloat() {
         final String key = "TEST_FLOAT";
         final float expected = 12.3f;
@@ -53,6 +99,18 @@ public class PreferenceUtilTest extends AndroidTestCase {
 
         PreferenceUtil.put(key, expected);
         float actual = PreferenceUtil.get(key, defValue);
+        assertEquals(expected, actual);
+    }
+
+    @SmallTest
+    public void testStoreFloatNamed() {
+        final String name = "TEST_NAMED";
+        final String key = "TEST_FLOAT";
+        final float expected = 12.3f;
+        final float defValue = 0.0f;
+
+        PreferenceUtil.put(name, key, expected);
+        float actual = PreferenceUtil.get(name, key, defValue);
         assertEquals(expected, actual);
     }
 
@@ -68,6 +126,18 @@ public class PreferenceUtilTest extends AndroidTestCase {
     }
 
     @SmallTest
+    public void testStoreLongNamed() {
+        final String name = "TEST_NAMED";
+        final String key = "TEST_LONG";
+        final long expected = 321L;
+        final long defValue = 0L;
+
+        PreferenceUtil.put(name, key, expected);
+        long actual = PreferenceUtil.get(name, key, defValue);
+        assertEquals(expected, actual);
+    }
+
+    @SmallTest
     public void testStoreString() {
         final String key = "TEST_STRING";
         final String expected = "Lorem ipsum";
@@ -75,6 +145,18 @@ public class PreferenceUtilTest extends AndroidTestCase {
 
         PreferenceUtil.put(key, expected);
         String actual = PreferenceUtil.get(key, defValue);
+        assertEquals(expected, actual);
+    }
+
+    @SmallTest
+    public void testStoreStringNamed() {
+        final String name = "TEST_NAMED";
+        final String key = "TEST_STRING";
+        final String expected = "Lorem ipsum";
+        final String defValue = null;
+
+        PreferenceUtil.put(name, key, expected);
+        String actual = PreferenceUtil.get(name, key, defValue);
         assertEquals(expected, actual);
     }
 
@@ -89,6 +171,21 @@ public class PreferenceUtilTest extends AndroidTestCase {
 
         PreferenceUtil.put(key, expected);
         Set<String> actual = PreferenceUtil.get(key, defValue);
+        assertEquals(expected, actual);
+    }
+
+    @SmallTest
+    public void testStoreStringSetNamed() {
+        final String name = "TEST_NAMED";
+        final String key = "TEST_STRINGSET";
+        final Set<String> expected = new HashSet<>();
+        expected.add("Lorem ipsum");
+        expected.add("dolor sit amet");
+        expected.add("consectetur adipiscing elit");
+        final Set<String> defValue = null;
+
+        PreferenceUtil.put(name, key, expected);
+        Set<String> actual = PreferenceUtil.get(name, key, defValue);
         assertEquals(expected, actual);
     }
 
@@ -107,6 +204,22 @@ public class PreferenceUtilTest extends AndroidTestCase {
         assertEquals(expected, actual);
     }
 
+    @MediumTest
+    public void testStoreSerializableNamed() {
+        final String name = "TEST_NAMED";
+        final String key = "TEST_SERIALIZABLE";
+        final ArrayList<String> expected = new ArrayList<>();
+        expected.add("Lorem ipsum");
+        expected.add("dolor sit amet");
+        expected.add("consectetur adipiscing elit");
+        final ArrayList<String> defValue = new ArrayList<>();
+        defValue.add("Proin mollis dictum");
+
+        PreferenceUtil.put(name, key, expected);
+        ArrayList<String> actual = PreferenceUtil.get(name, key, defValue);
+        assertEquals(expected, actual);
+    }
+
     @SmallTest
     public void testRemove() {
         final String key = "TEST_REMOVE";
@@ -116,6 +229,49 @@ public class PreferenceUtilTest extends AndroidTestCase {
         PreferenceUtil.remove(key);
         String actual = PreferenceUtil.get(key, expected);
         assertEquals(expected, actual);
+    }
+
+    @SmallTest
+    public void testRemoveNamed() {
+        final String name = "TEST_NAMED";
+        final String key = "TEST_REMOVE";
+        final String expected = null;
+
+        PreferenceUtil.put(name, key, "Lorem ipsum");
+        PreferenceUtil.remove(name, key);
+        String actual = PreferenceUtil.get(name, key, expected);
+        assertEquals(expected, actual);
+    }
+
+    @SmallTest
+    public void testClear() {
+        final String[] keys = {"TEST_REMOVE_1", "TEST_REMOVE_2", "TEST_REMOVE_2"};
+        final String expected = null;
+
+        for (String key : keys) {
+            PreferenceUtil.put(key, "Lorem ipsum");
+        }
+        PreferenceUtil.clear();
+        for (String key : keys) {
+            String actual = PreferenceUtil.get(key, expected);
+            assertEquals(expected, actual);
+        }
+    }
+
+    @SmallTest
+    public void testClearNamed() {
+        final String name = "TEST_NAMED";
+        final String[] keys = {"TEST_REMOVE_1", "TEST_REMOVE_2", "TEST_REMOVE_2"};
+        final String expected = null;
+
+        for (String key : keys) {
+            PreferenceUtil.put(name, key, "Lorem ipsum");
+        }
+        PreferenceUtil.clear(name);
+        for (String key : keys) {
+            String actual = PreferenceUtil.get(name, key, expected);
+            assertEquals(expected, actual);
+        }
     }
 
 }

--- a/utils/src/main/java/com/thefinestartist/utils/etc/PreferenceUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/etc/PreferenceUtil.java
@@ -26,49 +26,89 @@ public class PreferenceUtil {
 
     private static final String TAG = PreferenceUtil.class.getCanonicalName();
 
-    protected static final String PREFERENCES_NAME = PreferenceUtil.class.getCanonicalName();
+    private static String defaultName = PreferenceUtil.class.getCanonicalName();
+
 
     private PreferenceUtil() { }
 
 
-    private static SharedPreferences getPreferences() {
-        return Base.getContext().getSharedPreferences(
-                PREFERENCES_NAME, Context.MODE_PRIVATE);
+    private static SharedPreferences getPreferences(String name) {
+        return Base.getContext().getSharedPreferences(name, Context.MODE_PRIVATE);
+    }
+
+
+    public static String getDefaultName() {
+        return defaultName;
+    }
+
+    public static void setDefaultName(String name) {
+        defaultName = name;
     }
 
 
     public static boolean get(String key, boolean defValue) {
-        return getPreferences().getBoolean(key, defValue);
+        return get(defaultName, key, defValue);
     }
 
     public static int get(String key, int defValue) {
-        return getPreferences().getInt(key, defValue);
+        return get(defaultName, key, defValue);
     }
 
     public static float get(String key, float defValue) {
-        return getPreferences().getFloat(key, defValue);
+        return get(defaultName, key, defValue);
     }
 
     public static long get(String key, long defValue) {
-        return getPreferences().getLong(key, defValue);
+        return get(defaultName, key, defValue);
     }
 
     public static String get(String key, String defValue) {
-        return getPreferences().getString(key, defValue);
+        return get(defaultName, key, defValue);
     }
 
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public static Set<String> get(String key, Set<String> defValue) {
-        return getPreferences().getStringSet(key, defValue);
+        return get(defaultName, key, defValue);
     }
 
     @TargetApi(Build.VERSION_CODES.FROYO)
     public static <C extends Serializable> C get(String key, C defValue) {
+        return get(defaultName, key, defValue);
+    }
+
+
+    public static boolean get(String name, String key, boolean defValue) {
+        return getPreferences(name).getBoolean(key, defValue);
+    }
+
+    public static int get(String name, String key, int defValue) {
+        return getPreferences(name).getInt(key, defValue);
+    }
+
+    public static float get(String name, String key, float defValue) {
+        return getPreferences(name).getFloat(key, defValue);
+    }
+
+    public static long get(String name, String key, long defValue) {
+        return getPreferences(name).getLong(key, defValue);
+    }
+
+    public static String get(String name, String key, String defValue) {
+        return getPreferences(name).getString(key, defValue);
+    }
+
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    public static Set<String> get(String name, String key, Set<String> defValue) {
+        return getPreferences(name).getStringSet(key, defValue);
+    }
+
+    @TargetApi(Build.VERSION_CODES.FROYO)
+    public static <C extends Serializable> C get(String name, String key, C defValue) {
         ByteArrayInputStream bais = null;
         ObjectInputStream ois = null;
         C result = defValue;
 
-        String value = getPreferences().getString(key, null);
+        String value = getPreferences(name).getString(key, null);
         if (value != null) {
             try {
                 byte[] decoded = Base64.decode(value.getBytes(), Base64.DEFAULT);
@@ -102,32 +142,63 @@ public class PreferenceUtil {
 
 
     public static void put(String key, boolean value) {
-        getPreferences().edit().putBoolean(key, value).commit();
+        put(defaultName, key, value);
     }
 
     public static void put(String key, int value) {
-        getPreferences().edit().putInt(key, value).commit();
+        put(defaultName, key, value);
     }
 
     public static void put(String key, float value) {
-        getPreferences().edit().putFloat(key, value).commit();
+        put(defaultName, key, value);
     }
 
     public static void put(String key, long value) {
-        getPreferences().edit().putLong(key, value).commit();
+        put(defaultName, key, value);
     }
 
     public static void put(String key, String value) {
-        getPreferences().edit().putString(key, value).commit();
+        put(defaultName, key, value);
     }
 
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public static void put(String key, Set<String> value) {
-        getPreferences().edit().putStringSet(key, value).commit();
+        put(defaultName, key, value);
     }
 
     @TargetApi(Build.VERSION_CODES.FROYO)
     public static <C extends Serializable> void put(String key, C value) {
+        put(defaultName, key, value);
+    }
+
+
+    public static void put(String name, String key, boolean value) {
+        getPreferences(name).edit().putBoolean(key, value).commit();
+    }
+
+    public static void put(String name, String key, int value) {
+        getPreferences(name).edit().putInt(key, value).commit();
+    }
+
+    public static void put(String name, String key, float value) {
+        getPreferences(name).edit().putFloat(key, value).commit();
+    }
+
+    public static void put(String name, String key, long value) {
+        getPreferences(name).edit().putLong(key, value).commit();
+    }
+
+    public static void put(String name, String key, String value) {
+        getPreferences(name).edit().putString(key, value).commit();
+    }
+
+    @TargetApi(Build.VERSION_CODES.HONEYCOMB)
+    public static void put(String name, String key, Set<String> value) {
+        getPreferences(name).edit().putStringSet(key, value).commit();
+    }
+
+    @TargetApi(Build.VERSION_CODES.FROYO)
+    public static <C extends Serializable> void put(String name, String key, C value) {
         ByteArrayOutputStream baos = null;
         ObjectOutputStream oos = null;
 
@@ -136,7 +207,7 @@ public class PreferenceUtil {
             oos = new ObjectOutputStream(baos);
             oos.writeObject(value);
             byte[] encoded = Base64.encode(baos.toByteArray(), Base64.DEFAULT);
-            getPreferences().edit().putString(key, new String(encoded)).commit();
+            getPreferences(name).edit().putString(key, new String(encoded)).commit();
 
         } catch (IOException e) {
             Log.e(TAG, e.toString());
@@ -162,7 +233,20 @@ public class PreferenceUtil {
 
 
     public static void remove(String key) {
-        getPreferences().edit().remove(key).commit();
+        remove(defaultName, key);
+    }
+
+    public static void remove(String name, String key) {
+        getPreferences(name).edit().remove(key).commit();
+    }
+
+
+    public static void clear() {
+        clear(defaultName);
+    }
+
+    public static void clear(String name) {
+        getPreferences(name).edit().clear().commit();
     }
 
 }


### PR DESCRIPTION
`PreferenceUtil` now offers the interface discussed in #4, with the exception of the variable length argument list for the `remove` methods.

The used preference name is now configurable, with the ability to set the default name as well as the ability to use other preference names temporarily through alternative versions of every method. Methods for removing all preferences were also added.

Unfortunately, the variable length argument list for the `remove` methods are impossible to incorporate with the current design. The `remove(String... key)` and `remove(String name, String... keys)` methods would've been ambiguous.