### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/compilers/src/main/java/com/thefinestartist/compilers/Constants.java
+++ b/compilers/src/main/java/com/thefinestartist/compilers/Constants.java
@@ -5,6 +5,8 @@ package com.thefinestartist.compilers;
  */
 public class Constants {
 
+    private Constants() {}
+
     public static final String SUFFIX = "$$ExtraBinder";
 
     public static final String BINDING_ACTIVITY = "        activity.%s = (%s) bundle.get(\"%s\");";

--- a/compilers/src/main/java/com/thefinestartist/compilers/TypeElementUtil.java
+++ b/compilers/src/main/java/com/thefinestartist/compilers/TypeElementUtil.java
@@ -9,6 +9,8 @@ import javax.lang.model.type.NoType;
  */
 public class TypeElementUtil {
 
+    private TypeElementUtil() {}
+
     public static boolean instanceOf(TypeElement typeElement, Class clazz) {
         if (typeElement == null || typeElement instanceof NoType) {
             return false;

--- a/utils/src/main/java/com/thefinestartist/Base.java
+++ b/utils/src/main/java/com/thefinestartist/Base.java
@@ -14,6 +14,8 @@ import android.util.DisplayMetrics;
  */
 public class Base {
 
+    private Base() {}
+
     private static Context context;
 
     public static void initialize(@NonNull Context context) {

--- a/utils/src/main/java/com/thefinestartist/binders/ExtrasBinder.java
+++ b/utils/src/main/java/com/thefinestartist/binders/ExtrasBinder.java
@@ -15,6 +15,8 @@ import java.lang.reflect.Method;
  */
 public class ExtrasBinder {
 
+    private ExtrasBinder() {}
+
     static final String SUFFIX = "$$ExtraBinder";
 
     public static void bind(Activity activity) {

--- a/utils/src/main/java/com/thefinestartist/converters/UnitConverter.java
+++ b/utils/src/main/java/com/thefinestartist/converters/UnitConverter.java
@@ -9,6 +9,8 @@ import com.thefinestartist.Base;
  */
 public class UnitConverter {
 
+    private UnitConverter() {}
+
     public static float dpToPx(float dp) {
         return dp * Base.getDisplayMetrics().density;
     }

--- a/utils/src/main/java/com/thefinestartist/utils/content/ContextUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/content/ContextUtil.java
@@ -55,6 +55,8 @@ import java.io.InputStream;
  */
 public class ContextUtil {
 
+    private ContextUtil() {}
+
     public static boolean bindService(Intent service, ServiceConnection conn, int flags) {
         return Base.getContext().bindService(service, conn, flags);
     }

--- a/utils/src/main/java/com/thefinestartist/utils/content/ResourcesUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/content/ResourcesUtil.java
@@ -43,6 +43,8 @@ import java.io.InputStream;
  */
 public class ResourcesUtil {
 
+    private ResourcesUtil() {}
+
     private static void finishPreloading() {
         Base.getResources().finishPreloading();
     }

--- a/utils/src/main/java/com/thefinestartist/utils/content/ThemeUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/content/ThemeUtil.java
@@ -20,6 +20,8 @@ import com.thefinestartist.Base;
  */
 public class ThemeUtil {
 
+    private ThemeUtil() {}
+
     public static void applyStyle(int resId, boolean force) {
         Base.getTheme().applyStyle(resId, force);
     }

--- a/utils/src/main/java/com/thefinestartist/utils/content/TypedValueUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/content/TypedValueUtil.java
@@ -11,6 +11,8 @@ import com.thefinestartist.Base;
  */
 public class TypedValueUtil {
 
+    private TypedValueUtil() {}
+
     public static float applyDimension(int unit, float value) {
         return TypedValue.applyDimension(unit, value, Base.getDisplayMetrics());
     }

--- a/utils/src/main/java/com/thefinestartist/utils/etc/APILevel.java
+++ b/utils/src/main/java/com/thefinestartist/utils/etc/APILevel.java
@@ -9,6 +9,8 @@ import android.os.Build;
  */
 public class APILevel {
 
+    private APILevel() {}
+
     /**
      * @param level minimum API level version that has to support the device
      * @return true when the caller API version is at least level

--- a/utils/src/main/java/com/thefinestartist/utils/etc/IntArrayUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/etc/IntArrayUtil.java
@@ -7,6 +7,8 @@ package com.thefinestartist.utils.etc;
  */
 public class IntArrayUtil {
 
+    private IntArrayUtil() {}
+
     public static boolean contains(int[] array, int value) {
         if (array == null)
             return false;

--- a/utils/src/main/java/com/thefinestartist/utils/etc/PackageUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/etc/PackageUtil.java
@@ -14,6 +14,8 @@ import com.thefinestartist.Base;
  */
 public class PackageUtil {
 
+    private PackageUtil() {}
+
     public static String FACEBOOK = "com.facebook.katana";
     public static String TWITTER = "com.twitter.android";
     public static String GOOGLE_PLUS = "com.google.android.apps.plus";

--- a/utils/src/main/java/com/thefinestartist/utils/etc/SparseArrayUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/etc/SparseArrayUtil.java
@@ -11,6 +11,8 @@ import java.util.ArrayList;
  */
 public class SparseArrayUtil {
 
+    private SparseArrayUtil() {}
+
     public static <C> ArrayList<C> asArrayList(SparseArray<C> sparseArray) {
         if (sparseArray == null)
             return new ArrayList<C>();

--- a/utils/src/main/java/com/thefinestartist/utils/etc/ThreadUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/etc/ThreadUtil.java
@@ -9,6 +9,8 @@ import android.os.Looper;
  */
 public class ThreadUtil {
 
+    private ThreadUtil() {}
+
     public static boolean isMain() {
         return Looper.myLooper() == Looper.getMainLooper();
     }

--- a/utils/src/main/java/com/thefinestartist/utils/etc/TypefaceUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/etc/TypefaceUtil.java
@@ -14,6 +14,8 @@ import com.thefinestartist.Base;
  */
 public class TypefaceUtil {
 
+    private TypefaceUtil() {}
+
     private static final SimpleArrayMap<String, Typeface> cache = new SimpleArrayMap<>();
 
     public static Typeface get(@NonNull String path) {

--- a/utils/src/main/java/com/thefinestartist/utils/preferences/PreferencesUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/preferences/PreferencesUtil.java
@@ -25,6 +25,8 @@ import java.util.Set;
  */
 public class PreferencesUtil {
 
+    private PreferencesUtil() {}
+
     private static final LogHelper LogHelper = new LogHelper(PreferencesUtil.class);
     private static String defaultName = PreferencesUtil.class.getCanonicalName();
 

--- a/utils/src/main/java/com/thefinestartist/utils/service/ClipboardManagerUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/service/ClipboardManagerUtil.java
@@ -13,6 +13,8 @@ import com.thefinestartist.utils.etc.APILevel;
  */
 public class ClipboardManagerUtil {
 
+    private ClipboardManagerUtil() {}
+
     public static void setText(CharSequence text) {
         android.text.ClipboardManager clipboardManager = ServiceUtil.getClipboardManager();
         if (APILevel.require(11)) {

--- a/utils/src/main/java/com/thefinestartist/utils/service/ServiceUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/service/ServiceUtil.java
@@ -68,6 +68,8 @@ import com.thefinestartist.Base;
  */
 public class ServiceUtil {
 
+    private ServiceUtil() {}
+
     public static Object getSystemService(@NonNull String serviceName) {
         return Base.getContext().getSystemService(serviceName);
     }

--- a/utils/src/main/java/com/thefinestartist/utils/service/VibratorUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/service/VibratorUtil.java
@@ -11,6 +11,8 @@ import android.os.Vibrator;
  */
 public class VibratorUtil {
 
+    private VibratorUtil() {}
+
     @TargetApi(11)
     public static boolean hasVibrator() {
         return ServiceUtil.getVibrator().hasVibrator();

--- a/utils/src/main/java/com/thefinestartist/utils/service/WindowManagerUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/service/WindowManagerUtil.java
@@ -11,6 +11,8 @@ import android.view.WindowManager;
  */
 public class WindowManagerUtil {
 
+    private WindowManagerUtil() {}
+
     public static Display getDefaultDisplay() {
         return ServiceUtil.getWindowManager().getDefaultDisplay();
     }

--- a/utils/src/main/java/com/thefinestartist/utils/ui/DisplayUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/ui/DisplayUtil.java
@@ -18,6 +18,8 @@ import com.thefinestartist.utils.service.WindowManagerUtil;
  */
 public class DisplayUtil {
 
+    private DisplayUtil() {}
+
     public static int getWidth() {
         Display display = WindowManagerUtil.getDefaultDisplay();
         if (APILevel.require(13)) {

--- a/utils/src/main/java/com/thefinestartist/utils/ui/KeyboardUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/ui/KeyboardUtil.java
@@ -26,6 +26,8 @@ import com.thefinestartist.utils.service.ServiceUtil;
  */
 public class KeyboardUtil {
 
+    private KeyboardUtil() {}
+
     /**
      * Helps to show keyboard in {@link Activity#onCreate(Bundle)}, {@link Activity#onStart()},
      * {@link Activity#onResume()},

--- a/utils/src/main/java/com/thefinestartist/utils/ui/ViewUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/ui/ViewUtil.java
@@ -15,6 +15,8 @@ import com.thefinestartist.utils.etc.APILevel;
  */
 public class ViewUtil {
 
+    private ViewUtil() {}
+
     public static void setBackground(View view, Drawable drawable) {
         if (view == null)
             return;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
 
Please let me know if you have any questions.

Faisal Hameed