### PR TITLE
Code quality fix - The members of an interface declaration or class should appear in a pre-defined order.

### DIFF
--- a/compilers/src/main/java/com/thefinestartist/compilers/ExtraCompiler.java
+++ b/compilers/src/main/java/com/thefinestartist/compilers/ExtraCompiler.java
@@ -35,14 +35,15 @@ import javax.tools.JavaFileObject;
 @SupportedAnnotationTypes("com.thefinestartist.annotations.Extra")
 public class ExtraCompiler extends AbstractProcessor {
 
-    @Override
-    public SourceVersion getSupportedSourceVersion() {
-        return SourceVersion.latestSupported();
-    }
 
     Filer filer;
     Messager messager;
     Types types;
+
+    @Override
+    public SourceVersion getSupportedSourceVersion() {
+        return SourceVersion.latestSupported();
+    }
 
     @Override
     public synchronized void init(ProcessingEnvironment processingEnv) {

--- a/utils/src/main/java/com/thefinestartist/utils/log/LogUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/log/LogUtil.java
@@ -18,10 +18,6 @@ public class LogUtil {
     // Defaults
     private static Settings defaultSettings = new Settings(LogUtil.class.getSimpleName());
 
-    public static Settings getDefaultSettings() {
-        return defaultSettings;
-    }
-
     // Singleton
     private static volatile LogHelper logHelper = new LogHelper()
             .tag(defaultSettings.getTag())
@@ -29,6 +25,10 @@ public class LogUtil {
             .stackTraceCount(defaultSettings.getStackTraceCount())
             .logLevel(defaultSettings.getLogLevel())
             .showDivider(defaultSettings.getShowDivider());
+
+    public static Settings getDefaultSettings() {
+        return defaultSettings;
+    }
 
     public static LogHelper getInstance() {
         return logHelper;

--- a/utils/src/main/java/com/thefinestartist/utils/ui/KeyboardUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/ui/KeyboardUtil.java
@@ -26,6 +26,11 @@ import com.thefinestartist.utils.service.ServiceUtil;
  */
 public class KeyboardUtil {
 
+    public static int height = 0;
+    public static final String KEYBOARD_UTIL_PREF = "KEYBOARD_UTIL_PREF";
+    public static final String KEYBOARD_HEIGHT = "KEYBOARD_HEIGHT";
+    public static final int DEFAULT_KEYBOARD_HEIGHT = 200;
+
     /**
      * Helps to show keyboard in {@link Activity#onCreate(Bundle)}, {@link Activity#onStart()},
      * {@link Activity#onResume()},
@@ -111,11 +116,6 @@ public class KeyboardUtil {
         view.clearFocus();
         ServiceUtil.getInputMethodManager().hideSoftInputFromWindow(view.getWindowToken(), 0);
     }
-
-    public static int height = 0;
-    public static final String KEYBOARD_UTIL_PREF = "KEYBOARD_UTIL_PREF";
-    public static final String KEYBOARD_HEIGHT = "KEYBOARD_HEIGHT";
-    public static final int DEFAULT_KEYBOARD_HEIGHT = 200;
 
     public static int getHeight() {
         if (height <= 0)


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213

Please let me know if you have any questions.

Faisal Hameed