### PR TITLE
Orientation is now determined by screen size rather than rotation. (issue #29)

### DIFF
--- a/utils/src/main/java/com/thefinestartist/utils/ui/DisplayUtil.java
+++ b/utils/src/main/java/com/thefinestartist/utils/ui/DisplayUtil.java
@@ -48,13 +48,11 @@ public class DisplayUtil {
     }
 
     public static boolean isPortrait() {
-        Rotation rotation = getRotation();
-        return rotation == Rotation.DEGREES_0 || rotation == Rotation.DEGREES_180;
+        return getHeight() >= getWidth();
     }
 
     public static boolean isLandscape() {
-        Rotation rotation = getRotation();
-        return rotation == Rotation.DEGREES_90 || rotation == Rotation.DEGREES_270;
+        return getHeight() < getWidth();
     }
 
     public static int getStatusBarHeight() {


### PR DESCRIPTION
Changed the `DisplayUtil.isPortrait()`/`DisplayUtil.isLandscape()` methods to consider screen dimensions rather than rotation. This change should fix the issue seen on tablets and similar devices where landscape is the default orientation (issue #29).

The new approach is still slightly biased towards portrait mode by determining square (1:1 aspect ratio) displays to be in portrait mode. This seemed appropriate as portrait mode appears* to be the preferred orientation for Android Wear, which is the only type of device that I know of with 1:1 displays.

_* Please correct me if I'm wrong. It's based on what I've managed to find through some online research, but I don't have access to a Wear device to confirm._